### PR TITLE
Minecraft 26.2 support and 2.1.0 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please add the plugin to your Velocity server's plugins folder. Make sure you ar
 
 ### Requirements
 * Java 21+
-* Velocity 3.5.0 build 584+
+* Velocity 3.5.0 build 604+
 
 ## Developers
 VelocityScoreboardAPI is available [on Maven](https://repo.william278.net/#/releases/net/william278/velocityscoreboardapi/). You can browse the Javadocs [here](https://repo.william278.net/javadoc/releases/net/william278/velocityscoreboardapi/latest).

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 javaVersion=21
 
-project_version=2.0.0
+project_version=2.1.0
 project_archive=velocity-scoreboard-api
 project_description=Provides an API for interfacing with Scoreboards & Teams on Velocity proxies

--- a/plugin/src/main/java/com/velocitypowered/scoreboardapi/VelocityScoreboardAPI.java
+++ b/plugin/src/main/java/com/velocitypowered/scoreboardapi/VelocityScoreboardAPI.java
@@ -96,7 +96,7 @@ public class VelocityScoreboardAPI implements ScoreboardEventSource {
             }
         } catch (NoSuchFieldError e) {
             LoggerManager.log(Level.ERROR,"<red>" + "-".repeat(80));
-            LoggerManager.log(Level.ERROR,"<red>The plugin requires Velocity build #584 and up to work.");
+            LoggerManager.log(Level.ERROR,"<red>The plugin requires Velocity build #604 and up to work.");
             LoggerManager.log(Level.ERROR,"<red>" + "-".repeat(80));
             return;
         }

--- a/proxy/src/main/java/com/velocitypowered/proxy/scoreboard/TeamProperties.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/scoreboard/TeamProperties.java
@@ -85,6 +85,20 @@ public class TeamProperties {
      *          Protocol version used to decode the data
      */
     public TeamProperties(@NonNull ByteBuf buf, @NonNull ProtocolVersion protocolVersion) {
+        if (protocolVersion.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+            displayName = new TextHolderImpl(ComponentHolder.read(buf, protocolVersion));
+            prefix = new TextHolderImpl(ComponentHolder.read(buf, protocolVersion));
+            suffix = new TextHolderImpl(ComponentHolder.read(buf, protocolVersion));
+            nameVisibility = NameVisibility.values()[ProtocolUtils.readVarInt(buf)];
+            collisionRule = CollisionRule.values()[ProtocolUtils.readVarInt(buf)];
+            if (buf.readBoolean()) {
+                color = COLORS[ProtocolUtils.readVarInt(buf)];
+            }
+            byte flags = buf.readByte();
+            allowFriendlyFire = (flags & 0x01) > 0;
+            canSeeFriendlyInvisibles = (flags & 0x02) > 0;
+            return;
+        }
         if (protocolVersion.lessThan(ProtocolVersion.MINECRAFT_1_13)) {
             displayName = TextHolder.of(ProtocolUtils.readString(buf));
             prefix = TextHolder.of((ProtocolUtils.readString(buf)));
@@ -125,6 +139,23 @@ public class TeamProperties {
      *          Protocol version used to encode data
      */
     public void encode(@NonNull ByteBuf buf, @NonNull ProtocolVersion protocolVersion) {
+        byte flags = 0;
+        if (allowFriendlyFire) flags += 0x01;
+        if (canSeeFriendlyInvisibles) flags += 0x02;
+
+        if (protocolVersion.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+            ((TextHolderImpl)displayName).getHolder(protocolVersion).write(buf);
+            ((TextHolderImpl)prefix).getHolder(protocolVersion).write(buf);
+            ((TextHolderImpl)suffix).getHolder(protocolVersion).write(buf);
+            ProtocolUtils.writeVarInt(buf, nameVisibility.ordinal());
+            ProtocolUtils.writeVarInt(buf, collisionRule.ordinal());
+            buf.writeBoolean(color != TeamColor.RESET); // Since field is NotNull, let's make RESET act as null here
+            if (color != TeamColor.RESET) {
+                ProtocolUtils.writeVarInt(buf, Math.min(15, color.ordinal()));
+            }
+            buf.writeByte(flags);
+            return;
+        }
         if (protocolVersion.lessThan(ProtocolVersion.MINECRAFT_1_13)) {
             ProtocolUtils.writeString(buf, displayName.getLegacyText(16));
             ProtocolUtils.writeString(buf, prefix.getLegacyText(16));
@@ -132,9 +163,6 @@ public class TeamProperties {
         } else {
             ((TextHolderImpl)displayName).getHolder(protocolVersion).write(buf);
         }
-        byte flags = 0;
-        if (allowFriendlyFire) flags += 0x01;
-        if (canSeeFriendlyInvisibles) flags += 0x02;
         buf.writeByte(flags);
         if (protocolVersion.noLessThan(ProtocolVersion.MINECRAFT_1_21_5)) {
             ProtocolUtils.writeVarInt(buf, nameVisibility.ordinal());

--- a/proxy/src/main/java/com/velocitypowered/proxy/scoreboard/VelocityScoreboard.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/scoreboard/VelocityScoreboard.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 public class VelocityScoreboard implements ProxyScoreboard {
 
-    public static final ProtocolVersion MAXIMUM_SUPPORTED_VERSION = ProtocolVersion.MINECRAFT_26_1;
+    public static final ProtocolVersion MAXIMUM_SUPPORTED_VERSION = ProtocolVersion.MINECRAFT_26_2;
 
     @NonNull
     @Getter


### PR DESCRIPTION
Team color is now an optional int with only 16 supported colors. Map all magic codes down to 15. Use RESET to represent `null` color.