### PR TITLE
ci: add automatic Modrinth builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,41 +1,133 @@
-# Builds, tests and publishes to maven when a commit is pushed
-name: CI Tests & Publish
+# Builds and publishes to Modrinth when a commit is pushed to master
+name: Build & Publish to Modrinth
 
 on:
   push:
     branches: [ 'master' ]
     paths-ignore:
-      - 'workflows/**'
       - 'README.md'
+      - '.gitignore'
+  workflow_dispatch:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout for CI 🛎️'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
       - name: 'Set up JDK 21 📦'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
+
       - name: 'Build with Gradle 🏗️'
-        run: ./gradlew build publish
-        env:
-          SNAPSHOTS_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          SNAPSHOTS_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-      - name: Set short SHA
-        run: echo "SHORT_SHA=$(echo $GITHUB_SHA | cut -c 1-7)" >> $GITHUB_ENV
-      - name: Find first built VelocityScoreboardAPI jar
-        run: |
-          FIRST_BUILT_FILE=$(ls target/VelocityScoreboardAPI-*-${{ env.SHORT_SHA }}.jar | sort | head -n 1)
-          echo "FIRST_BUILT_FILE=$FIRST_BUILT_FILE" >> $GITHUB_ENV
-      - name: Upload first built VelocityScoreboardAPI jar
-        uses: actions/upload-artifact@v4
+        uses: gradle/gradle-build-action@v3
         with:
-          name: VelocityScoreboardAPI
-          path: ${{ env.FIRST_BUILT_FILE }}
+          arguments: clean build --refresh-dependencies
+
+      - name: 'Fetch Version Name 📝'
+        run: |
+          echo "VERSION_NAME=$(./gradlew properties --no-daemon --console=plain -q | awk '/^version:/ { print $2 }')" >> "$GITHUB_ENV"
+
+      - name: 'Publish to Modrinth 🚀'
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          modrinth-featured: false
+          files: target/VelocityScoreboardAPI-${{ env.VERSION_NAME }}.jar
+          name: VelocityScoreboardAPI ${{ env.VERSION_NAME }}
+          version: ${{ env.VERSION_NAME }}
+          version-type: beta
+          loaders: velocity
+          game-versions: |
+            1.7.2
+            1.7.3
+            1.7.4
+            1.7.5
+            1.7.6
+            1.7.7
+            1.7.8
+            1.7.9
+            1.7.10
+            1.8
+            1.8.1
+            1.8.2
+            1.8.3
+            1.8.4
+            1.8.5
+            1.8.6
+            1.8.7
+            1.8.8
+            1.8.9
+            1.9
+            1.9.1
+            1.9.2
+            1.9.3
+            1.9.4
+            1.10
+            1.10.1
+            1.10.2
+            1.11
+            1.11.1
+            1.11.2
+            1.12
+            1.12.1
+            1.12.2
+            1.13
+            1.13.1
+            1.13.2
+            1.14
+            1.14.1
+            1.14.2
+            1.14.3
+            1.14.4
+            1.15
+            1.15.1
+            1.15.2
+            1.16
+            1.16.1
+            1.16.2
+            1.16.3
+            1.16.4
+            1.16.5
+            1.17
+            1.17.1
+            1.18
+            1.18.1
+            1.18.2
+            1.19
+            1.19.1
+            1.19.2
+            1.19.3
+            1.19.4
+            1.20
+            1.20.1
+            1.20.2
+            1.20.3
+            1.20.4
+            1.20.5
+            1.20.6
+            1.21
+            1.21.1
+            1.21.2
+            1.21.3
+            1.21.4
+            1.21.5
+            1.21.6
+            1.21.7
+            1.21.8
+            1.21.9
+            1.21.10
+            1.21.11
+            26.1
+            26.1.1
+            26.1.2
+            26.2
+          java: 21
+          fail-mode: fail


### PR DESCRIPTION
## Summary
- build on every push to `master`
- publish the built VelocityScoreboardAPI jar to Modrinth via `Kir-Antipov/mc-publish@v3.3`
- use `MODRINTH_TOKEN` secret and `MODRINTH_PROJECT_ID` repository variable

## Verification
- `/tmp/actionlint-bin/actionlint .github/workflows/ci.yml`
- `./gradlew clean build --refresh-dependencies --no-daemon --stacktrace` → `BUILD SUCCESSFUL`