### PR TITLE
Add config option to toggle labymod bug compensation

### DIFF
--- a/plugin/src/main/java/com/velocitypowered/scoreboardapi/PluginConfig.java
+++ b/plugin/src/main/java/com/velocitypowered/scoreboardapi/PluginConfig.java
@@ -56,6 +56,9 @@ public class PluginConfig {
     @Comment("Whether to log invalid packets received from downstream servers")
     private boolean printInvalidDownstreamPacketWarnings = true;
 
+    @Comment("Whether to compensate for a bug in LabyMod. Enabling this breaks support for proxies with disabled configuration phase.")
+    private boolean labymodBugCompensation = true;
+
     @NotNull
     public static PluginConfig load(@NotNull Path directory) {
         return YamlConfigurations.update(

--- a/plugin/src/main/java/com/velocitypowered/scoreboardapi/ServerSwitchManager.java
+++ b/plugin/src/main/java/com/velocitypowered/scoreboardapi/ServerSwitchManager.java
@@ -84,7 +84,9 @@ public class ServerSwitchManager {
             downstreamScoreboard.clear();
             proxyScoreboard.freeze();
         }
-        plugin.getServer().getScheduler().buildTask(plugin, proxyScoreboard::resend).schedule();
+        if (player.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_20_5) || plugin.getPluginConfig().isLabymodBugCompensation()) {
+            plugin.getServer().getScheduler().buildTask(plugin, proxyScoreboard::resend).schedule();
+        }
     }
 
     /**
@@ -94,7 +96,7 @@ public class ServerSwitchManager {
      */
     @Subscribe
     public void onJoin(PostLoginEvent e) {
-        if (e.getPlayer().getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_20_5)) {
+        if (e.getPlayer().getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_20_5) || plugin.getPluginConfig().isLabymodBugCompensation()) {
             try {
                 ((ConnectedPlayer) e.getPlayer()).getConnection().getChannel().pipeline().addBefore(
                         "handler", "VelocityScoreboardAPI", new ChannelInjection(e.getPlayer())
@@ -128,7 +130,7 @@ public class ServerSwitchManager {
      */
     @Subscribe
     public void onConfigFinish(@NotNull PlayerFinishConfigurationEvent e) {
-        if (e.player().getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_5)) {
+        if (e.player().getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_5) && !plugin.getPluginConfig().isLabymodBugCompensation()) {
             ((VelocityScoreboard) VelocityScoreboardManager.getInstance().getProxyScoreboard(e.player())).resend();
         }
     }

--- a/plugin/src/main/java/com/velocitypowered/scoreboardapi/VelocityScoreboardAPI.java
+++ b/plugin/src/main/java/com/velocitypowered/scoreboardapi/VelocityScoreboardAPI.java
@@ -52,6 +52,8 @@ public class VelocityScoreboardAPI implements ScoreboardEventSource {
     @Getter
     private final ProxyServer server;
     private final Metrics.Factory metricsFactory;
+
+    @Getter
     private final PluginConfig pluginConfig;
 
     /**


### PR DESCRIPTION
Labymod creates new level instance with scoreboard on join game packet, unlike vanilla, which recreates it on configuration phase finish. 
This means it is no longer possible to support both configuration phase disabled as well as this buggy client, as the behavior on server switch is now different in those cases (labymod would clear the scoreboard, vanilla would not). 

This solution adds a config option where people have to choose - either support buggy clients, or disabled configuration phase. Defaults to labymod bug compensation as configuration phase disabling is only part of a fork, and people are probably not using it much since doing that causes problems.